### PR TITLE
Add Bill of Materials

### DIFF
--- a/hardware/Mechanicals-BTU-Mod/BOM.MD
+++ b/hardware/Mechanicals-BTU-Mod/BOM.MD
@@ -1,0 +1,12 @@
+3x Bosch-Rexroth R053010810 (KU-B8-OFK)
+  -Nominal Diameter = 12.6mm
+  -Nominal Insertion Depth = 6.4mm
+  -Nominal Ball Diameter = 8mm
+  -Nominal Flange Diameter = 17mm
+  -Nominal Unit Height = 11.2mm
+  
+4x Heat Set M3 Threaded Inserts
+  -Flanged Preferred
+  -Installed Length ~5.7mm
+  -For 4mm hole diameter
+  -Through-hole Insert Preferred


### PR DESCRIPTION
Current README.MD has part numbers for BTUs, but doesn't have a part number for threaded inserts, or specific description of the necessary part (eg. installed length, flange, blind hole).